### PR TITLE
first attempt at power analysis in shiny

### DIFF
--- a/StatisticsInR/anova-power.R
+++ b/StatisticsInR/anova-power.R
@@ -1,0 +1,152 @@
+library(shiny)
+library(tidyverse)
+library(broom)
+source("../Templates/biostats_theme.R")
+theme_set(theme_bw())
+
+
+ui <-  fluidPage(
+  # Application title
+  titlePanel("Simulating an ANOVA"),
+  
+  sidebarLayout(
+    # Sidebar with a slider input
+    sidebarPanel(
+      sliderInput(
+        "n",
+        "Number of observations:",
+        min = 2,
+        max = 100,
+        value = 10,
+        step = 1
+      ),
+      sliderInput(
+        "delta",
+        "True difference in means:",
+        min = 0,
+        max = 10,
+        value = 5
+      ),
+      sliderInput(
+        "sd",
+        "Standard deviation of each group:",
+        min = 0,
+        max = 10,
+        value = 5
+      ),
+      sliderInput(
+        "p",
+        "p level:",
+        min = 0,
+        max = 1,
+        value = 0.05, 
+        step = 0.01
+      )
+    ),
+    
+    
+    # Show a plot of the generated distribution
+    mainPanel(
+      h4("Population distributions"),
+      plotOutput("pop_plot"),
+      h4(textOutput("samp_size")),
+      plotOutput("sample_plot"),
+      h4("Confidence intervals on 100 trials"),
+      plotOutput("uncertainty_plot"),
+      h4("Effect size of 100 trials"),
+      plotOutput("effect_plot"),
+      h4("P-values of 100 trials"),
+      plotOutput("p_plot")
+    )
+  ))
+
+server <- function(input, output) {
+  
+  output$samp_size <- renderText(glue::glue("Sample of {input$n} observations for each treatment"))
+    
+  output$pop_plot <- renderPlot({
+    upper <- max(0, input$delta) + input$sd * 3
+    lower <- min(0, input$delta) - input$sd * 3
+    
+    dist <- bind_rows(
+      control = tibble(
+        x = seq(lower, upper, length.out = 101),
+        y = dnorm(x, mean = 0, sd = input$sd)
+      ),
+      treatment = tibble(
+        x = seq(lower, upper, length.out = 101),
+        y = dnorm(x, mean = input$delta, sd = input$sd)
+      ),
+      .id = "treatment"
+    )
+                                        
+    
+    pop_plot <- ggplot(data = dist, aes(x = x, y = y, fill = treatment)) +
+      geom_area(alpha = 0.3, position = "identity") +
+      geom_vline(mapping = aes(xintercept = x, colour = treatment), data = tibble(x = c(0, input$delta), treatment = c("control", "treat")), show.legend = FALSE) +
+      labs(x = "Value", y = "Density", fill = "Treatment") 
+    
+    pop_plot
+  })
+  
+  mods <- reactive({
+    message("reactive called")
+    sims <- rerun(100, tibble(treatment = rep(c("control", "treat"), each = input$n),
+                      value = rnorm(n = input$n * 2, 
+                                    mean = rep(c(0, input$delta), each = input$n), 
+                                    sd = input$sd)
+                      ))
+  
+  
+  list(
+    result = map(sims, ~lm(formula = value ~ treatment, data = .x)) %>% 
+    map_dfr(tidy) %>% 
+    filter(term != "(Intercept)") %>%
+    arrange(estimate) %>% 
+    mutate(n = row_number()),
+    sample = sims[[1]]
+  )
+  
+  })
+  
+  output$p_plot <- renderPlot({
+    ggplot(mods()$result, aes(x = p.value, fill = p.value < input$p)) + 
+      geom_histogram(boundary = 0, bins = 100) +
+      xlim(0, 1) +
+      geom_vline(xintercept = input$p, colour = "red", linetype = "dashed") +
+      labs(x = "P value", fill = glue::glue("p < {input$p}"))
+  })
+  
+ output$effect_plot <- renderPlot({
+  ggplot(mods()$result, aes(x = estimate, fill = p.value < input$p)) + 
+    geom_histogram(bins = 25) +
+    geom_vline(xintercept = input$delta) +
+    labs(
+      x = "Estimated difference in means",
+      fill = glue::glue("p < {input$p}"))
+})
+ 
+ output$uncertainty_plot <- renderPlot({
+   ggplot(mods()$result, aes(x = estimate, xmin =  estimate - 1.96 * std.error, xmax = estimate + 1.96 * std.error, y = n)) + 
+     geom_errorbarh() +
+     geom_point() +
+     geom_vline(xintercept = input$delta) +
+     geom_vline(xintercept = 0, linetype = "dashed") +
+     labs(x = "Estimated difference in means")
+ })
+ 
+ output$sample_plot <- renderPlot({
+   ggplot(mods()$sample, aes(x = treatment, y = value)) + 
+     geom_boxplot(aes(fill = treatment), alpha = 0.3, outlier.shape = NA) + 
+     geom_jitter(aes(colour = treatment), height = 0) +
+ #    stat_summary(fun.data = "mean_sd") +
+     # geom_vline(xintercept = input$delta) +
+     # geom_vline(xintercept = 0, linetype = "dashed") +
+     labs(x = "Treatment") +
+     theme(legend.position = "none")
+ })
+ 
+  output
+}
+  
+shinyApp(ui, server)

--- a/StatisticsInR/anova-power.R
+++ b/StatisticsInR/anova-power.R
@@ -61,7 +61,7 @@ ui <-  fluidPage(
       ),
       fluidRow(
         column(4, 
-          h4("Confidence intervals on 100 trials"),
+          h4("Confidence intervals of 100 trials"),
           plotOutput("uncertainty_plot")
         ),
         column(4,
@@ -160,12 +160,13 @@ server <- function(input, output) {
       geom_histogram(boundary = 0, bins = 100) +
       xlim(0, 1) +
       geom_vline(xintercept = input$p, colour = "red", linetype = "dashed") +
-      labs(x = "P value", fill = glue::glue("p < {input$p}"))
+      labs(x = "P value", fill = glue::glue("p < {input$p}")) +
+      theme(legend.position = c(.99, .99), legend.justification = c(1, 1))
   })
   
  output$effect_plot <- renderPlot({
   ggplot(mods()$result, aes(x = estimate, fill = p.value < input$p)) + 
-    geom_histogram(bins = 25) +
+    geom_histogram(bins = 25, show.legend = FALSE) +
     geom_vline(xintercept = input$delta) +
     labs(
       x = if_else(input$type == "Categorical", "Estimated difference in means", "Estimated slope"),
@@ -178,6 +179,7 @@ server <- function(input, output) {
      geom_point() +
      geom_vline(xintercept = input$delta) +
      geom_vline(xintercept = 0, linetype = "dashed") +
+     scale_y_continuous(expand = c(0.01, 0.01)) +
      labs(x = if_else(input$type == "Categorical", "Estimated difference in means", "Estimated slope"), 
           y = "Simulation number")
  })

--- a/StatisticsInR/anova-power.R
+++ b/StatisticsInR/anova-power.R
@@ -7,11 +7,13 @@ theme_set(theme_bw())
 
 ui <-  fluidPage(
   # Application title
-  titlePanel("Simulating an ANOVA"),
+  titlePanel("Simulating linear regressions"),
   
   sidebarLayout(
+   
     # Sidebar with a slider input
     sidebarPanel(
+      radioButtons("type", label = "Type of predictor variable", choices = c("Categorical", "Continuous"), selected = "Categorical"),
       sliderInput(
         "n",
         "Number of observations:",
@@ -60,42 +62,70 @@ ui <-  fluidPage(
     )
   ))
 
+#### Server ####
 server <- function(input, output) {
+  max_continuous <- 2
   
-  output$samp_size <- renderText(glue::glue("Sample of {input$n} observations for each treatment"))
+  output$samp_size <- renderText({
+    if (input$type == "Categorical") {
+      glue::glue("Sample of {input$n} observations for each treatment")
+    } else {
+      glue::glue("Sample of {input$n} observations") 
+    }
+  })
     
   output$pop_plot <- renderPlot({
-    upper <- max(0, input$delta) + input$sd * 3
-    lower <- min(0, input$delta) - input$sd * 3
     
-    dist <- bind_rows(
-      control = tibble(
-        x = seq(lower, upper, length.out = 101),
-        y = dnorm(x, mean = 0, sd = input$sd)
-      ),
-      treatment = tibble(
-        x = seq(lower, upper, length.out = 101),
-        y = dnorm(x, mean = input$delta, sd = input$sd)
-      ),
-      .id = "treatment"
-    )
-                                        
-    
-    pop_plot <- ggplot(data = dist, aes(x = x, y = y, fill = treatment)) +
-      geom_area(alpha = 0.3, position = "identity") +
-      geom_vline(mapping = aes(xintercept = x, colour = treatment), data = tibble(x = c(0, input$delta), treatment = c("control", "treat")), show.legend = FALSE) +
-      labs(x = "Value", y = "Density", fill = "Treatment") 
-    
+    if (input$type == "Categorical") {
+      upper <- max(0, input$delta) + input$sd * 3
+      lower <- min(0, input$delta) - input$sd * 3
+      
+      dist <- bind_rows(
+        control = tibble(
+          x = seq(lower, upper, length.out = 101),
+          y = dnorm(x, mean = 0, sd = input$sd)
+        ),
+        treatment = tibble(
+          x = seq(lower, upper, length.out = 101),
+          y = dnorm(x, mean = input$delta, sd = input$sd)
+        ),
+        .id = "treatment"
+      )
+      
+      pop_plot <- ggplot(data = dist, aes(x = x, y = y, fill = treatment)) +
+        geom_area(alpha = 0.3, position = "identity") +
+        geom_vline(mapping = aes(xintercept = x, colour = treatment), data = tibble(x = c(0, input$delta), treatment = c("control", "treat")), show.legend = FALSE) +
+        labs(x = "Value", y = "Density", fill = "Treatment") 
+    } else {
+      
+      dist <- tibble(x = seq(0, max_continuous, length.out = 50),
+                     value = x * input$delta) 
+      
+      pop_plot <- ggplot(data = dist, aes(x = x, y = value)) +
+        geom_ribbon(aes(ymin = value - 2 * input$sd, ymax = value + 2 * input$sd), alpha = 0.3) +
+        geom_ribbon(aes(ymin = value - input$sd, ymax = value + input$sd), alpha = 0.3) +
+        geom_line() +
+        labs(x = "Predictor", y = "Response") 
+    }
     pop_plot
   })
   
+  
+  #simulate data
   mods <- reactive({
-    message("reactive called")
-    sims <- rerun(100, tibble(treatment = rep(c("control", "treat"), each = input$n),
-                      value = rnorm(n = input$n * 2, 
-                                    mean = rep(c(0, input$delta), each = input$n), 
-                                    sd = input$sd)
-                      ))
+    if (input$type == "Categorical") {
+      sims <- rerun(100, tibble(treatment = rep(c("control", "treat"), each = input$n),
+                                value = rnorm(n = input$n * 2, 
+                                              mean = rep(c(0, input$delta), each = input$n), 
+                                              sd = input$sd)
+      ))
+    } else { #simulate continuous data
+      sims <- rerun(100, tibble(treatment = runif(input$n, 0, max_continuous),
+                                value = treatment * input$delta + 
+                                  rnorm(n = input$n, mean = 0, sd = input$sd)
+      ))
+    }
+
   
   
   list(
@@ -122,7 +152,7 @@ server <- function(input, output) {
     geom_histogram(bins = 25) +
     geom_vline(xintercept = input$delta) +
     labs(
-      x = "Estimated difference in means",
+      x = if_else(input$type == "Categorical", "Estimated difference in means", "Estimated slope"),
       fill = glue::glue("p < {input$p}"))
 })
  
@@ -132,18 +162,26 @@ server <- function(input, output) {
      geom_point() +
      geom_vline(xintercept = input$delta) +
      geom_vline(xintercept = 0, linetype = "dashed") +
-     labs(x = "Estimated difference in means")
+     labs(x = if_else(input$type == "Categorical", "Estimated difference in means", "Estimated slope"), 
+          y = "Simulation number")
  })
  
  output$sample_plot <- renderPlot({
-   ggplot(mods()$sample, aes(x = treatment, y = value)) + 
-     geom_boxplot(aes(fill = treatment), alpha = 0.3, outlier.shape = NA) + 
-     geom_jitter(aes(colour = treatment), height = 0) +
- #    stat_summary(fun.data = "mean_sd") +
-     # geom_vline(xintercept = input$delta) +
-     # geom_vline(xintercept = 0, linetype = "dashed") +
-     labs(x = "Treatment") +
-     theme(legend.position = "none")
+     if (input$type == "Categorical") {
+       ggplot(mods()$sample, aes(x = treatment, y = value)) + 
+         geom_boxplot(aes(fill = treatment), alpha = 0.3, outlier.shape = NA) + 
+         geom_jitter(aes(colour = treatment), height = 0) +
+         #    stat_summary(fun.data = "mean_sd") +
+         # geom_vline(xintercept = input$delta) +
+         # geom_vline(xintercept = 0, linetype = "dashed") +
+         labs(x = "Treatment", y = "Response") +
+         theme(legend.position = "none")
+     } else {
+       ggplot(mods()$sample, aes(x = treatment, y = value)) + 
+         geom_point() +
+         geom_smooth(method = "lm", formula = y ~ x) +
+         labs(x = "Predictor", y = "Response")
+     }
  })
  
   output

--- a/StatisticsInR/anova-power.R
+++ b/StatisticsInR/anova-power.R
@@ -12,7 +12,7 @@ ui <-  fluidPage(
   sidebarLayout(
    
     # Sidebar with a slider input
-    sidebarPanel(
+    sidebarPanel(width = 3,
       radioButtons("type", label = "Type of predictor variable", choices = c("Categorical", "Continuous"), selected = "Categorical"),
       sliderInput(
         "n",
@@ -48,17 +48,31 @@ ui <-  fluidPage(
     
     
     # Show a plot of the generated distribution
-    mainPanel(
-      h4("Population distributions"),
-      plotOutput("pop_plot"),
-      h4(textOutput("samp_size")),
-      plotOutput("sample_plot"),
-      h4("Confidence intervals on 100 trials"),
-      plotOutput("uncertainty_plot"),
-      h4("Effect size of 100 trials"),
-      plotOutput("effect_plot"),
-      h4("P-values of 100 trials"),
-      plotOutput("p_plot")
+    mainPanel(width = 9,
+      fluidRow(
+        column(6, 
+          h4("Population distributions"),
+          plotOutput("pop_plot")
+        ),
+        column(6,
+          h4(textOutput("samp_size")),
+          plotOutput("sample_plot")
+        )
+      ),
+      fluidRow(
+        column(4, 
+          h4("Confidence intervals on 100 trials"),
+          plotOutput("uncertainty_plot")
+        ),
+        column(4,
+          h4("Effect size of 100 trials"),
+          plotOutput("effect_plot")
+        ),
+        column(4,
+          h4("P-values of 100 trials"),
+          plotOutput("p_plot")
+        )
+      )
     )
   ))
 
@@ -85,7 +99,7 @@ server <- function(input, output) {
           x = seq(lower, upper, length.out = 101),
           y = dnorm(x, mean = 0, sd = input$sd)
         ),
-        treatment = tibble(
+        treat = tibble(
           x = seq(lower, upper, length.out = 101),
           y = dnorm(x, mean = input$delta, sd = input$sd)
         ),
@@ -95,7 +109,9 @@ server <- function(input, output) {
       pop_plot <- ggplot(data = dist, aes(x = x, y = y, fill = treatment)) +
         geom_area(alpha = 0.3, position = "identity") +
         geom_vline(mapping = aes(xintercept = x, colour = treatment), data = tibble(x = c(0, input$delta), treatment = c("control", "treat")), show.legend = FALSE) +
-        labs(x = "Value", y = "Density", fill = "Treatment") 
+        labs(x = "Value", y = "Density", fill = "Treatment") +
+        theme(legend.position = c(.99, .99), legend.justification = c(1, 1))
+        
     } else {
       
       dist <- tibble(x = seq(0, max_continuous, length.out = 50),


### PR DESCRIPTION
This is a shiny app for showing a power analysis of  an ANOVA. It is designed to be embedded into a page about power (not just p-values, but width of confidence intervals etc). At the moment, you can run it with the Run App button in Rstudio.

I wanted to start with a t-test, but that gives the effect the opposite sign unless I messed with the factor levels.

I'm thinking of 
- shrinking the plots so they all fit on one page
- annotating the plots to show what is going on
- adding a second tab to show the equivalent for linear regression with a continuous predictor. DONE but some sliderInput labels needs modifying depending on type of predictor and not sure how to do that

Any suggestions on how to improve the app are welcome.